### PR TITLE
Remove default order from acts_as_commentable

### DIFF
--- a/lib/acts_as_commentable_with_threading.rb
+++ b/lib/acts_as_commentable_with_threading.rb
@@ -17,7 +17,7 @@ module Acts #:nodoc:
 
   module ClassMethods
     def acts_as_commentable
-      has_many :comment_threads, :class_name => "Comment", :as => :commentable, :dependent => :destroy, :order => 'created_at ASC'
+      has_many :comment_threads, :class_name => "Comment", :as => :commentable, :dependent => :destroy
       include Acts::CommentableWithThreading::LocalInstanceMethods
       extend Acts::CommentableWithThreading::SingletonMethods
     end


### PR DESCRIPTION
It is impossible to override this default order:

```
ruby-1.9.2-p0 >p.root_comments.order('comments.created_at DESC').collect {|c| c.created_at}
 => [Wed, 08 Dec 2010 09:08:26 UTC +00:00, Wed, 08 Dec 2010 09:16:19 UTC +00:00, Wed, 08 Dec 2010   09:17:26 UTC +00:00] 
ruby-1.9.2-p0 > p.root_comments.order('comments.created_at ASC').collect {|c| c.created_at}
 => [Wed, 08 Dec 2010 09:08:26 UTC +00:00, Wed, 08 Dec 2010 09:16:19 UTC +00:00, Wed, 08 Dec 2010     09:17:26 UTC +00:00] 
```

This is the resulting sql:

```
ruby-1.9.2-p0 > p.root_comments.order('comments.created_at DESC').to_sql
 => "SELECT `comments`.* FROM `comments` WHERE (`comments`.commentable_id = 16790001 AND `comments`.commentable_type = 'Product') AND (`comments`.`parent_id` IS NULL) ORDER BY created_at ASC, comments.created_at DESC"
```

This chaining was not intended. You can only override this with a default_scope for the whole application. Then, in turn, you cannot specify a chronological order for comments within a thread.
