### PR TITLE
Corrected typo: act_as_votable not act_as_votEable.

### DIFF
--- a/lib/generators/acts_as_commentable_upgrade_migration/comment.rb
+++ b/lib/generators/acts_as_commentable_upgrade_migration/comment.rb
@@ -6,7 +6,7 @@ class Comment < ActiveRecord::Base
 
   # NOTE: install the acts_as_votable plugin if you
   # want user to vote on the quality of comments.
-  #acts_as_voteable
+  #acts_as_votable
 
   belongs_to :commentable, :polymorphic => true
 


### PR DESCRIPTION
When uncommenting the line, the comment.rb gets crazy. Use the correct behavior and everything works fine now.
