### PR TITLE
Typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,16 +81,12 @@ Usage
 
         @comment.children
 
-* If you plan to use the `acts_as_voteable` plugin with your comment system be
+* If you plan to use the `acts_as_votable` plugin with your comment system be
   sure to uncomment two things:
 
-  * In `lib/comment.rb` uncomment the line [`acts_as_voteable`][L9].
-
-  * In `lib/acts_as_commentable_with_threading.rb` uncomment the line
-    [`include Juixe::Acts::Voteable`][L5] near the top.
+  * In `lib/comment.rb` uncomment the line [`acts_as_votable`][L9].
 
 [L9]: https://github.com/elight/acts_as_commentable_with_threading/blob/master/lib/generators/acts_as_commentable_with_threading_migration/templates/comment.rb#L9
-[L5]: https://github.com/elight/acts_as_commentable_with_threading/blob/master/lib/acts_as_commentable_with_threading.rb#L5
 
 Credits
 -------

--- a/lib/generators/acts_as_commentable_with_threading_migration/templates/comment.rb
+++ b/lib/generators/acts_as_commentable_with_threading_migration/templates/comment.rb
@@ -6,7 +6,7 @@ class Comment < ActiveRecord::Base
 
   # NOTE: install the acts_as_votable plugin if you
   # want user to vote on the quality of comments.
-  #acts_as_voteable
+  #acts_as_votable
 
   belongs_to :commentable, :polymorphic => true
 


### PR DESCRIPTION
Hello,
I updated the documentation to match the acts_as_votable
Also I removed a comment that was pointing to no line.
hope it helps
