### PR TITLE
order comment threads explicitly and only fetch root comments

### DIFF
--- a/lib/acts_as_commentable_with_threading.rb
+++ b/lib/acts_as_commentable_with_threading.rb
@@ -16,7 +16,7 @@ module Acts #:nodoc:
 
   module ClassMethods
     def acts_as_commentable
-      has_many :comment_threads, :class_name => "Comment", :as => :commentable, :dependent => :destroy, :order => "#{table_name}.lft, #{table_name}.id", :conditions => { :parent_id => nil }  
+      has_many :comment_threads, :class_name => "Comment", :as => :commentable, :dependent => :destroy, :order => "#{Comment.table_name}.lft, #{Comment.table_name}.id", :conditions => { :parent_id => nil }  
       include Acts::CommentableWithThreading::LocalInstanceMethods
       extend Acts::CommentableWithThreading::SingletonMethods
     end


### PR DESCRIPTION
We had a problem in our app: Destroying a commentable record did invoke all the :destroy hooks by the `has_many :comment_threads` but under certian circumstances it tried to load records it already deleted before. My first guess was the undeterministic order of deletion, but even then it happened.

My seconds guess aimed towards the tree structure. If awesome_nested_set cares about deletion of descendents, `:comment_threads` only has to return its `roots` and let `ans`  work from there.

So here it is, works OK for us :)
