### PR TITLE
Rename sqlite3 gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,6 @@ group :development do
   gem "rake", ">= 0"
   gem "bundler"
   gem "rspec", "~> 1.3"
-  gem "sqlite3-ruby", ">= 0"
+  gem "sqlite3", ">= 0"
   gem "rails", "~> 3.2"
 end


### PR DESCRIPTION
Removes the post-install message from Bundler:

```
#######################################################

Hello! The sqlite3-ruby gem has changed it's name to just sqlite3.  Rather than
installing `sqlite3-ruby`, you should install `sqlite3`.  Please update your
dependencies accordingly.

Thanks from the Ruby sqlite3 team!

<3 <3 <3 <3
#######################################################
```

Cheers,
  Lee :beers:
