### PR TITLE
Fixing gemspec / Active Support 4 incompatibility

### DIFF
--- a/acts_as_commentable_with_threading.gemspec
+++ b/acts_as_commentable_with_threading.gemspec
@@ -14,9 +14,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler', '~> 1.0'
   s.add_development_dependency 'rspec', '~> 1.3'
   s.add_development_dependency 'sqlite3-ruby'
-  s.add_development_dependency 'rails', '~> 3.0'
+  s.add_development_dependency 'rails', '>= 3.0'
 
   s.add_dependency 'activerecord', '>= 3.0'
-  s.add_dependency 'activesupport', '~> 3.0'
+  s.add_dependency 'activesupport', '>= 3.0'
   s.add_dependency 'awesome_nested_set', '>= 2.0'
 end


### PR DESCRIPTION
Fixing gemspec / Active Support 4 incompatibility. This patch prevents Rails 4 RC2 from erring out durring bundle install.

Here's the error that `bundle install` was giving:

```
Bundler could not find compatible versions for gem "activesupport":
  In Gemfile:
    acts_as_commentable_with_threading (>= 0) ruby depends on
      activesupport (~> 3.0) ruby

    rails (= 4.0.0.rc2) ruby depends on
      activesupport (4.0.0.rc2)
```
