### PR TITLE
add attr_accessible to comment

### DIFF
--- a/lib/generators/acts_as_commentable_upgrade_migration/comment.rb
+++ b/lib/generators/acts_as_commentable_upgrade_migration/comment.rb
@@ -1,5 +1,5 @@
 class Comment < ActiveRecord::Base
-  attr_accessible :commentable, :user_id, :body, :subject
+  attr_accessible :commentable, :user_id, :body, :subject, :title
 
   acts_as_nested_set :scope => [:commentable_id, :commentable_type]
 


### PR DESCRIPTION
add attr_accessible to comment, unless my spec will fail as

Failure/Error: @comment = Comment.build_from(child_post, user.id, "This is a comment body")
     ActiveModel::MassAssignmentSecurity::Error:
       Can't mass-assign protected attributes: commentable, body, user_id
     # ./app/models/comment.rb:25:in `new'

my spec is as following

describe "When create a new comment" do
    it "should be able to create a comment" do
      @comment = Comment.build_from(child_post, user.id, "This is a comment body")
      @comment.save
      @comment.body.should == "This is a comment body"

```
  child_post.root_comments.size.should == 1
end
```

  end

My rails version 3.2.13
