### PR TITLE
Address Rails 4 deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,12 +3,12 @@ source 'http://rubygems.org'
 
 gem "activerecord", "~> 4.0"
 gem "activesupport", "~> 4.0"
-gem "awesome_nested_set", "~> 2.1"
+gem "awesome_nested_set", "~> 3.0.0.rc.2"
 
 group :development do
   gem "rake", ">= 0"
   gem "bundler"
-  gem "rspec", "~> 1.3"
+  gem "rspec"
   gem "sqlite3", ">= 0"
   gem "rails", "~> 4.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,9 +27,10 @@ GEM
       tzinfo (~> 0.3.37)
     arel (4.0.1)
     atomic (1.1.14)
-    awesome_nested_set (2.1.6)
-      activerecord (>= 3.0.0)
+    awesome_nested_set (3.0.0.rc.2)
+      activerecord (~> 4.0.0)
     builder (3.1.4)
+    diff-lcs (1.2.5)
     erubis (2.7.0)
     hike (1.2.3)
     i18n (0.6.5)
@@ -57,7 +58,14 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.1.0)
-    rspec (1.3.2)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.7)
+    rspec-expectations (2.14.4)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.14.4)
     sprockets (2.10.0)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -67,7 +75,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
-    sqlite3 (1.3.7)
+    sqlite3 (1.3.8)
     thor (0.18.1)
     thread_safe (0.1.3)
       atomic
@@ -83,9 +91,9 @@ PLATFORMS
 DEPENDENCIES
   activerecord (~> 4.0)
   activesupport (~> 4.0)
-  awesome_nested_set (~> 2.1)
+  awesome_nested_set (~> 3.0.0.rc.2)
   bundler
   rails (~> 4.0)
   rake
-  rspec (~> 1.3)
+  rspec
   sqlite3

--- a/gemfiles/Gemfile.rails-4.0
+++ b/gemfiles/Gemfile.rails-4.0
@@ -4,7 +4,7 @@ gemspec path: '..'
 
 gem 'activerecord', '~> 4.0.0'
 gem 'activesupport', '~> 4.0.0'
-gem 'awesome_nested_set','~> 2.1'
+gem 'awesome_nested_set','~> 3.0.0.rc.2'
 
 group :development do
   gem 'rake'


### PR DESCRIPTION
1. Update Rails 4 versions to use 3.0.x branch of awesome_nested_set.
2. Fix bad rspec version in Gemfile
