### PR TITLE
fix migration

### DIFF
--- a/lib/generators/acts_as_commentable_with_threading_migration/templates/migration.rb
+++ b/lib/generators/acts_as_commentable_with_threading_migration/templates/migration.rb
@@ -5,7 +5,7 @@ class ActsAsCommentableWithThreadingMigration < ActiveRecord::Migration
       t.string :commentable_type
       t.string :title
       t.text :body
-      t.string :subject{}
+      t.string :subject
       t.integer :user_id, :default => 0, :null => false
       t.integer :parent_id, :lft, :rgt
       t.timestamps


### PR DESCRIPTION
remove the pair of brace, since it leads to
`syntax error, unexpected '{', expecting keyword_end t.string :subject{}`
