### PR TITLE
Get specs running under JRuby

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .rvmrc
+.ruby-version
 pkg/*
 spec/debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ gemfile:
 rvm:
   - 1.9.3
   - 2.0.0
+  - jruby-19mode

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :development do
   gem "rake", ">= 0"
   gem "bundler"
   gem "rspec"
-  gem "sqlite3", ">= 0"
+  gem 'activerecord-jdbcsqlite3-adapter', :platforms => :jruby
+  gem 'sqlite3', :platforms => :ruby
   gem "rails", "~> 4.0"
 end

--- a/acts_as_commentable_with_threading.gemspec
+++ b/acts_as_commentable_with_threading.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.4'
-  s.add_development_dependency 'sqlite3-ruby'
   s.add_development_dependency 'rails', '>= 3.0'
 
   s.add_dependency 'activerecord', '>= 3.0'

--- a/gemfiles/Gemfile.rails-3.0
+++ b/gemfiles/Gemfile.rails-3.0
@@ -8,7 +8,8 @@ gem "awesome_nested_set", "~> 2.0.0"
 
 group :development do
   gem 'rake'
-  gem 'sqlite3', '>= 0'
+  gem 'activerecord-jdbcsqlite3-adapter', :platforms => :jruby
+  gem 'sqlite3', :platforms => :ruby
   gem 'rails', '~> 3.0.0'
 end
 

--- a/gemfiles/Gemfile.rails-3.1
+++ b/gemfiles/Gemfile.rails-3.1
@@ -8,7 +8,8 @@ gem "awesome_nested_set", "~> 2.0.0"
 
 group :development do
   gem 'rake'
-  gem 'sqlite3', '>= 0'
+  gem 'activerecord-jdbcsqlite3-adapter', :platforms => :jruby
+  gem 'sqlite3', :platforms => :ruby
   gem 'rails', '~> 3.1.0'
 end
 

--- a/gemfiles/Gemfile.rails-3.2
+++ b/gemfiles/Gemfile.rails-3.2
@@ -8,7 +8,8 @@ gem "awesome_nested_set", "~> 2.1.0"
 
 group :development do
   gem 'rake'
-  gem 'sqlite3', '>= 0'
+  gem 'activerecord-jdbcsqlite3-adapter', :platforms => :jruby
+  gem 'sqlite3', :platforms => :ruby
   gem 'rails', '~> 3.2.0'
 end
 

--- a/gemfiles/Gemfile.rails-4.0
+++ b/gemfiles/Gemfile.rails-4.0
@@ -8,7 +8,8 @@ gem 'awesome_nested_set','~> 3.0.0.rc.2'
 
 group :development do
   gem 'rake'
-  gem 'sqlite3', '>= 0'
+  gem 'activerecord-jdbcsqlite3-adapter', :platforms => :jruby
+  gem 'sqlite3', :platforms => :ruby
   gem 'rails', '~> 4.0.0'
 end
 


### PR DESCRIPTION
1. Removed sqlite3 as a development dependency in the gemspec.  
2. Added JDBC SQLite to Gemfiles for JRuby platforms.
3. Added JRuby to .travis.yml
4. Added .ruby-version to .gitignore
