### PR TITLE
Use rbx-2 for travis, update to non-beta version of Rails 4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
   - 2.0.0
   - 2.1.0
   - jruby-19mode
-  - rbx
+  - rbx-2
 matrix:
   allow_failures:
     - gemfile: gemfiles/Gemfile.rails-4.1

--- a/gemfiles/Gemfile.rails-4.1
+++ b/gemfiles/Gemfile.rails-4.1
@@ -2,8 +2,8 @@ source 'http://rubygems.org'
 
 gemspec path: '..'
 
-gem 'activerecord', '~> 4.1.0.beta1'
-gem 'activesupport', '~> 4.1.0.beta1'
+gem 'activerecord', '~> 4.1.0'
+gem 'activesupport', '~> 4.1.0'
 gem 'awesome_nested_set','~> 3.0.0.rc.2'
 
 platforms :rbx do
@@ -15,7 +15,7 @@ group :development do
   gem 'rake'
   gem 'activerecord-jdbcsqlite3-adapter', :platforms => :jruby
   gem 'sqlite3', :platforms => :ruby
-  gem 'rails', '~> 4.1.0.beta1'
+  gem 'rails', '~> 4.1.0'
 end
 
 group :development, :test do


### PR DESCRIPTION
Fix Travis by using rbx-2 in .travis.yml
Remove the beta in the Rails 4.1 gemfile.
