### PR TITLE
Do not set default values for ID columns

### DIFF
--- a/lib/generators/acts_as_commentable_with_threading_migration/templates/migration.rb
+++ b/lib/generators/acts_as_commentable_with_threading_migration/templates/migration.rb
@@ -1,20 +1,20 @@
 class ActsAsCommentableWithThreadingMigration < ActiveRecord::Migration
   def self.up
     create_table :comments, :force => true do |t|
-      t.integer :commentable_id, :default => 0
+      t.integer :commentable_id
       t.string :commentable_type
       t.string :title
       t.text :body
       t.string :subject
-      t.integer :user_id, :default => 0, :null => false
+      t.integer :user_id, :null => false
       t.integer :parent_id, :lft, :rgt
       t.timestamps
     end
-    
+
     add_index :comments, :user_id
     add_index :comments, [:commentable_id, :commentable_type]
   end
-  
+
   def self.down
     drop_table :comments
   end

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -2,18 +2,18 @@ ActiveRecord::Schema.define(:version => 1) do
   create_table "users", :force => true do |t|
     t.timestamps
   end
-  
+
   create_table "commentables", :force => true do |t|
     t.timestamps
   end
 
   create_table "comments", :force => true do |t|
-    t.integer "commentable_id", :default => 0
+    t.integer "commentable_id"
     t.string "commentable_type", :limit => 15, :default => ""
     t.string "title", :default => ""
     t.text "body", :default => ""
     t.string "subject", :default => ""
-    t.integer "user_id", :default => 0, :null => false
+    t.integer "user_id", :null => false
     t.integer "parent_id"
     t.integer "lft"
     t.integer "rgt"


### PR DESCRIPTION
This fixes an issue when specifying the `touch` option on the `belongs_to` association for comments. 

See [Rails issue #15826](https://github.com/rails/rails/issues/15826) for more information.
