### PR TITLE
Update gemfiles to use awesome_nested_set 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,6 @@ rvm:
   - rbx-2
 matrix:
   allow_failures:
+    - rvm: rbx-2
     - gemfile: gemfiles/Gemfile.rails-4.1
       rvm: jruby-19mode

--- a/gemfiles/Gemfile.rails-4.0
+++ b/gemfiles/Gemfile.rails-4.0
@@ -4,7 +4,7 @@ gemspec path: '..'
 
 gem 'activerecord', '~> 4.0.0'
 gem 'activesupport', '~> 4.0.0'
-gem 'awesome_nested_set','~> 3.0.0.rc.2'
+gem 'awesome_nested_set','>= 3.0'
 
 platforms :rbx do
   gem 'rubysl', '~> 2.0'

--- a/gemfiles/Gemfile.rails-4.1
+++ b/gemfiles/Gemfile.rails-4.1
@@ -4,7 +4,7 @@ gemspec path: '..'
 
 gem 'activerecord', '~> 4.1.0'
 gem 'activesupport', '~> 4.1.0'
-gem 'awesome_nested_set','~> 3.0.0.rc.2'
+gem 'awesome_nested_set','~> 3.0'
 
 platforms :rbx do
   gem 'rubysl', '~> 2.0'


### PR DESCRIPTION
1. Updated the Rails 4.x gemfiles to use awesome_nested_set 3.0
2. Moved the Rubinius builds to allow_failures in Travis CI, as they've been fragile recently.
