### PR TITLE
Explicitly declare the license type in the gemspec

### DIFF
--- a/acts_as_commentable_with_threading.gemspec
+++ b/acts_as_commentable_with_threading.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |s|
   s.authors  = ['Evan Light', 'Jack Dempsey', 'Xelipe', 'xxx']
   s.files    = `git ls-files`.split("\n")
   s.test_files = `git ls-files -- spec/*`.split("\n")
+  s.license = 'MIT'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '>= 3.0'


### PR DESCRIPTION
The gemspec does not explicitly declare the license type. `license` is a recommended attribute in the gemspec: http://guides.rubygems.org/specification-reference/#license=

This PR sets the license attribute to MIT because that is the license used by this repository.

This will assist in using this gem with other software that tracks software licenses, for example, the [papers](https://github.com/newrelic/papers) gem. It will require a release to rubygems.org.