### PR TITLE
Update gemfiles to use awesome_nested_set 3.2

### DIFF
--- a/acts_as_commentable_with_threading.gemspec
+++ b/acts_as_commentable_with_threading.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activerecord', '>= 4.0'
   s.add_dependency 'activesupport', '>= 4.0'
-  s.add_dependency 'awesome_nested_set', '>= 3.0'
+  s.add_dependency 'awesome_nested_set', '>= 3.2'
 end

--- a/gemfiles/Gemfile.rails-5.2
+++ b/gemfiles/Gemfile.rails-5.2
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+group :development do
+  gem 'activerecord-jdbcsqlite3-adapter', platforms: :jruby
+  gem 'sqlite3', platforms: :ruby
+  gem 'rails', '~> 5.2.0'
+end


### PR DESCRIPTION
An error occurs when using `@model.children` in an application of Rails 5.2.4.rc1 or later.
`wrong number of arguments (given 0, expected 1)`

This was solved in awesome_nested_set 3.2.0
https://github.com/collectiveidea/awesome_nested_set/pull/408